### PR TITLE
Fix bug in XmlComment.asOpenTag() where comment was not rendered on empty _name

### DIFF
--- a/source/kxml/xml.d
+++ b/source/kxml/xml.d
@@ -1249,11 +1249,7 @@ class XmlComment : XmlNode {
 
 	// internal function to generate opening tags
 	protected override string asOpenTag() {
-		if (_name.length == 0) {
-			return null;
-		}
-		auto s = "<!--" ~ _comment  ~ "-->";
-		return s;
+		return "<!--" ~ _comment  ~ "-->";
 	}
 
 	// internal function to generate closing tags


### PR DESCRIPTION
XmlComment doesn't use the _name field so this check was probably a copy/paste error.  It resulted in comments not being written when converting from the DOM objects to a rendered XML string.