### PR TITLE
Remove space from empty element name and slash (i.e., <blah/>)

### DIFF
--- a/source/kxml/xml.d
+++ b/source/kxml/xml.d
@@ -364,7 +364,7 @@ class XmlNode
 		auto s = "<" ~ _name ~ genAttrString();
 
 		if (_children.length == 0)
-			s ~= " /"; // We want <blah /> if the node has no children.
+			s ~= "/"; // We want <blah/> if the node has no children.
 		s ~= ">";
 
 		return s;


### PR DESCRIPTION
This removes the space between the name of an empty element and the following forward slash.  This results in `<blah/>` instead of `<blah />`.   This changes the XML string output, but I can't think of a compelling reason not to do it, since it is still valid XML and is more compact.